### PR TITLE
Add architecture guidelines and enforce CQS pattern with reactive streams

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,4 @@
+# AI Agent Instructions
+
+Refer to the project's architectural standards before implementing any logic:
+- [Architecture Guidelines](docs/architecture-guidelines.md)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,4 @@
+# Claude Instructions
+
+Follow the project's Mandatory CQS Use Case pattern and layer structure:
+- [Architecture Guidelines](docs/architecture-guidelines.md)

--- a/docs/architecture-guidelines.md
+++ b/docs/architecture-guidelines.md
@@ -1,0 +1,13 @@
+# Architecture Guidelines
+
+## 1. Layer Structure
+- **Domain Layer**: Contains Business Logic, Models, and Repository Interfaces.
+- **Data Layer**: Contains Repository Implementations, API Clients, and DTOs.
+
+## 2. Use Case Pattern: Mandatory CQS
+Every Use Case must follow a Reactive CQS (Command Query Separation) pattern to ensure architectural consistency and scalability.
+
+- **Trigger (Command)**: Use `suspend` functions (e.g., `fetch()`, `execute()`) to initiate actions. These should only emit parameters into internal flows.
+- **Stream (Query/State)**: Expose a `StateFlow` or `Flow` to provide the data, operation status, or completion results.
+- **Strict Rule**: Never return operation results directly from the `suspend` trigger functions. Consumers must subscribe to the exposed state stream.
+- **Benefit**: Decouples "action" from "state", handles race conditions via flow operators (e.g., `debounce`, `flatMapLatest`), and accommodates future complexity without changing the interface.


### PR DESCRIPTION
This pull request introduces new documentation to establish and clarify the project's architectural standards, with a focus on layering and the mandatory use of the CQS (Command Query Separation) pattern. The changes aim to ensure consistency and scalability across the codebase by providing clear guidelines for both general agent logic and Claude-specific instructions.

Architecture and process documentation:

* Added `docs/architecture-guidelines.md` to define the project's layer structure (Domain and Data layers) and to mandate a Reactive CQS use case pattern, including strict rules for triggers and state streams.

Agent and Claude-specific documentation:

* Added `AGENTS.md` with instructions for AI agents to consult the architecture guidelines before implementing any logic.
* Added `CLAUDE.md` with instructions for Claude to follow the mandatory CQS use case pattern and layer structure, referencing the architecture guidelines.